### PR TITLE
Change how binary/lib/dll directories are set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,6 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/flamegpu2.cmake)
 # Include common rules from the main repositorys CMake
 include(${FLAMEGPU_ROOT}/cmake/common.cmake)
 
-# Define output location of binary files
-SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin/${CMAKE_BUILD_TYPE}/)
-
 # Manually list all of the files which require building or influence re-building.
 SET(ALL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cu

--- a/cmake/flamegpu2.cmake
+++ b/cmake/flamegpu2.cmake
@@ -1,5 +1,10 @@
 include(FetchContent)
+include(FindPackageHandleStandardArgs)
 cmake_policy(SET CMP0079 NEW)
+
+# Find or fetch FLAME GPU 2
+# If FLAMEGPU_ROOT is set, check it exists and use it. Otherwise error.
+# Otherwise, fetch FLAMEGPU/FLAMEGPU2 from github, and use it in the _deps directory.  
 
 # If a FLAMEGPU_VERSION has not been defined, set it to the default option.
 if(NOT DEFINED FLAMEGPU_VERSION OR FLAMEGPU_VERSION STREQUAL "")
@@ -7,37 +12,65 @@ if(NOT DEFINED FLAMEGPU_VERSION OR FLAMEGPU_VERSION STREQUAL "")
 endif()
 
 # Allow users to switch to forks with relative ease.
-
 if(NOT DEFINED FLAMEGPU_REPOSITORY OR FLAMEGPU_REPOSITORY STREQUAL "")
     set(FLAMEGPU_REPOSITORY "https://github.com/FLAMEGPU/FLAMEGPU2.git" CACHE STRING "Remote Git Repository for FLAME GPU 2+")
 endif()
 
-# Always use most recent, simply recommend users that they may wish to do otherwise
-FetchContent_Declare(
-    flamegpu2
-    GIT_REPOSITORY ${FLAMEGPU_REPOSITORY}
-    GIT_TAG        ${FLAMEGPU_VERSION}
-    GIT_SHALLOW    1
-    GIT_PROGRESS   ON
-    # UPDATE_DISCONNECTED   ON
-)
+# If FLAMEGPU_ROOT is set, and it contains flame gpu do nothing. Otherwise download the appropraite version
+if(DEFINED FLAMEGPU_ROOT AND NOT FLAMEGPU_VERSION STREQUAL "")
+    #  Look for a file we expect to always exist. version.h is dynamically created so cannot be relied upon
+    find_path(FLAMEGPU_ROOT include/flamegpu/flamegpu.h
+        HINTS
+            $ENV{FLAMEGPU_ROOT}
+            ${FLAMEGPU_ROOT}
+        NO_DEFAULT_PATH
+        NO_PACKAGE_ROOT_PATH
+        NO_CMAKE_PATH
+        NO_CMAKE_ENVIRONMENT_PATH
+        NO_SYSTEM_ENVIRONMENT_PATH
+        NO_CMAKE_SYSTEM_PATH
+        DOC "Path to clone of FLAMEPU/FLAMEGPU2 source repository"
+    )
+    # Easy way to error if it could not be found?
+    find_package_handle_standard_args(FLAMEGPU2 "Failed to find FLAMEGPU root" FLAMEGPU_ROOT)
 
-# Fetch and populate the content if required.
-FetchContent_GetProperties(flamegpu2)
-if(NOT flamegpu2_POPULATED)
-    FetchContent_Populate(flamegpu2)   
-
-    # Now disable extra bells/whistles and add flamegpu2 as a dependency
+    # disable extra bells/whistles and add flamegpu2 as a dependency
     set(NO_EXAMPLES ON CACHE INTERNAL "-")
     set(BUILD_TESTS OFF CACHE BOOL "-")
     mark_as_advanced(FORCE BUILD_TESTS)
 
     # Add the subdirectory
-    add_subdirectory(${flamegpu2_SOURCE_DIR} ${flamegpu2_BINARY_DIR})
+    add_subdirectory(${FLAMEGPU_ROOT} "FLAMEGPU")
 
     # Add flamegpu2' expected location to the prefix path.
-    set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${flamegpu2_SOURCE_DIR}/cmake")
-endif()
+    set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${FLAMEGPU_ROOT}/cmake")
+else()
+    # Always use most recent, simply recommend users that they may wish to do otherwise
+    FetchContent_Declare(
+        flamegpu2
+        GIT_REPOSITORY ${FLAMEGPU_REPOSITORY}
+        GIT_TAG        ${FLAMEGPU_VERSION}
+        GIT_SHALLOW    1
+        GIT_PROGRESS   ON
+        # UPDATE_DISCONNECTED   ON
+    )
 
-message(STATUS "Found FLAMEGPU2 ${flamegpu2_SOURCE_DIR}")
-set(FLAMEGPU_ROOT ${flamegpu2_SOURCE_DIR})
+    # Fetch and populate the content if required.
+    FetchContent_GetProperties(flamegpu2)
+    if(NOT flamegpu2_POPULATED)
+        FetchContent_Populate(flamegpu2)   
+
+        # Now disable extra bells/whistles and add flamegpu2 as a dependency
+        set(NO_EXAMPLES ON CACHE INTERNAL "-")
+        set(BUILD_TESTS OFF CACHE BOOL "-")
+        mark_as_advanced(FORCE BUILD_TESTS)
+
+        # Add the subdirectory
+        add_subdirectory(${flamegpu2_SOURCE_DIR} ${flamegpu2_BINARY_DIR})
+
+        # Add flamegpu2' expected location to the prefix path.
+        set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${flamegpu2_SOURCE_DIR}/cmake")
+    endif()
+    set(FLAMEGPU_ROOT ${flamegpu2_SOURCE_DIR})
+endif()
+message(STATUS "Using FLAMEGPU2 ${FLAMEGPU_ROOT}")


### PR DESCRIPTION
Changes CMake archive/binary output directores are set, to be handeleed by updated logic in `common.cmake` rather than manually in the repository. 

Also adds `-DFLAMEGPU_ROOT=/path/to/local/FLAMEGPU2` as a mechanism to avoid  fetching remote FLAME GPU easily. This will need changing further once we have installation rules.


This change (coupled with the main repo change) does currently lead to `libflamegpu.a` being placed in `build/lib/<config>` rather than `_deps/flamegpu-builds/lib/<config>` which could be reverted to with a change in either repo. 


+ [ ] Re-test and merge after the main repo: https://github.com/FLAMEGPU/FLAMEGPU2/pull/653
+ [ ] Once confirmed apply this to other standalone repos.