### PR TITLE
Add FLAMEGPU_VERBOSE_PTXAS and FLAMEGPU_USE_GLM to the CMake options table

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ cmake --build . --config Release --target flamegpu boids_bruteforce --verbose
 | `FLAMEGPU_WARNINGS_AS_ERRORS`        | `ON`/`OFF`                  | Promote compiler/tool warnings to errors are build time. Default `OFF`                                     |
 | `FLAMEGPU_RTC_EXPORT_SOURCES`        | `ON`/`OFF`                  | At runtime, export dynamic RTC files to disk. Useful for debugging RTC models. Default `OFF`               |
 | `FLAMEGPU_RTC_DISK_CACHE`            | `ON`/`OFF`                  | Enable/Disable caching of RTC functions to disk. Default `ON`.                                             |
+| `FLAMEGPU_VERBOSE_PTXAS`             | `ON`/`OFF`                  | Enable verbose PTXAS output during compilation. Default `OFF`.                                             |
 | `FLAMEGPU_CURAND_ENGINE`             | `XORWOW` / `PHILOX` / `MRG` | Select the CUDA random engine. Default `XORWOW`                                                      |
+| `FLAMEGPU_USE_GLM`                   | `ON`/`OFF`                  | Experimental feature for GLM type support in RTC models. Default `OFF`.                                    |
 | `FLAMEGPU_SHARE_USAGE_STATISTICS`    | `ON`/`OFF`                  | Share usage statistics ([telemetry](https://docs.flamegpu.com/guide/telemetry)) to support evidencing usage/impact of the software. Default `ON`. |
 | `FLAMEGPU_TELEMETRY_SUPPRESS_NOTICE` | `ON`/`OFF`                  | Suppress notice encouraging telemetry to be enabled, which is emitted once per binary execution if telemetry is disabled. Defaults to `OFF`, or the value of a system environment variable of the same name. |
  


### PR DESCRIPTION
Add `FLAMEGPU_VERBOSE_PTXAS` and `FLAMEGPU_USE_GLM` to the CMake options table.