### PR TITLE
CMake: Do not place the model into an EXAMPLES sub filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ SET(ALL_SRC
 )
 
 # Add the executable and set required flags for the target
-flamegpu_add_executable("${PROJECT_NAME}" "${ALL_SRC}" "${FLAMEGPU_ROOT}" "${PROJECT_BINARY_DIR}" TRUE)
+flamegpu_add_executable("${PROJECT_NAME}" "${ALL_SRC}" "${FLAMEGPU_ROOT}" "${PROJECT_BINARY_DIR}" OFF)
 
 # Add src directory to include path
 target_include_directories("${PROJECT_NAME}" PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")


### PR DESCRIPTION
Models createdf from the template are not an flamegpu "example" in my opinion / by default, so don't place them there.

Not actually directly tested this in visual studio (i.e where filters are)