### PR TITLE
Include cfloat for FLT_MAX

### DIFF
--- a/src/main.cu
+++ b/src/main.cu
@@ -1,3 +1,4 @@
+#include <cfloat>
 #include "flamegpu/flamegpu.h"
 
 FLAMEGPU_AGENT_FUNCTION(outputMessage, flamegpu::MessageNone, flamegpu::MessageSpatial3D) {


### PR DESCRIPTION
cfloat/float.h is no longer an implicit include since a minor CUDA 12 version. Including `<cfloat>` resolves this error. 

This has previously been fixed in the main FLAMEGPU/FLAMEGPU2 repository